### PR TITLE
fix: go-mod

### DIFF
--- a/task/etc/task.yaml
+++ b/task/etc/task.yaml
@@ -11,14 +11,13 @@ Log:
   Compress: true # 是否压缩
   KeepDays: 7 # 保留天数
 
-#Etcd:
-#  Hosts:
-#  - localhost:2379
-#  - localhost:2379
-#  Key: user.rpc
+Etcd:
+  Hosts:
+  - 47.243.34.199:2379
+  Key: task.rpc
 
 DB:
-  DataSource: root:123456@tcp(localhost:3306)/adfi?charset=utf8&parseTime=True&loc=Local
+  DataSource: root:123456@tcp(localhost:3306)/adfi?charset=utf8&parseTime=True&loc=Local   #Todo：修改数据库连接 改成线上数据库
 Cache:
   - Host: "127.0.0.1:6379"
     pass: "123456"

--- a/task/internal/logic/DailyTaskCheck.go
+++ b/task/internal/logic/DailyTaskCheck.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/zeromicro/go-zero/core/logx"
-	"taskManager-Service-main/task/internal/model"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/model"
+	"task/internal/svc"
+	"task/task"
 )
 
 type DailyTaskCheckLogic struct {

--- a/task/internal/logic/amendassociatedsubtasklogic.go
+++ b/task/internal/logic/amendassociatedsubtasklogic.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/amendchestcollectionlogic.go
+++ b/task/internal/logic/amendchestcollectionlogic.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 	"time"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/amendtreasuretasklogic.go
+++ b/task/internal/logic/amendtreasuretasklogic.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/changetreasuretasklogic.go
+++ b/task/internal/logic/changetreasuretasklogic.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/createcuratorialtasklogic.go
+++ b/task/internal/logic/createcuratorialtasklogic.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 	"time"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/shopspring/decimal"
 	"github.com/zeromicro/go-zero/core/logx"

--- a/task/internal/logic/createlabellogic.go
+++ b/task/internal/logic/createlabellogic.go
@@ -3,10 +3,10 @@ package logic
 import (
 	"context"
 	"strings"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/createsubtaskstylelogic.go
+++ b/task/internal/logic/createsubtaskstylelogic.go
@@ -3,9 +3,9 @@ package logic
 import (
 	"context"
 	"database/sql"
-	"taskManager-Service-main/task/internal/model"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/model"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/createuserpowertasklogic.go
+++ b/task/internal/logic/createuserpowertasklogic.go
@@ -2,9 +2,9 @@ package logic
 
 import (
 	"context"
-	"taskManager-Service-main/task/internal/model"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/model"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/deleteassociatedsubtasklogic.go
+++ b/task/internal/logic/deleteassociatedsubtasklogic.go
@@ -3,8 +3,8 @@ package logic
 import (
 	"context"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/deletelabellogic.go
+++ b/task/internal/logic/deletelabellogic.go
@@ -3,8 +3,8 @@ package logic
 import (
 	"context"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/performtasklogic.go
+++ b/task/internal/logic/performtasklogic.go
@@ -3,8 +3,8 @@ package logic
 import (
 	"context"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/queryassociatedsubtasklogic.go
+++ b/task/internal/logic/queryassociatedsubtasklogic.go
@@ -2,8 +2,8 @@ package logic
 
 import (
 	"context"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/querychestcollectionlogic.go
+++ b/task/internal/logic/querychestcollectionlogic.go
@@ -2,9 +2,9 @@ package logic
 
 import (
 	"context"
-	"taskManager-Service-main/task/internal/model"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/model"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/querylabellistlogic.go
+++ b/task/internal/logic/querylabellistlogic.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )
@@ -40,7 +40,7 @@ func (l *QueryLabelListLogic) QueryLabelList(in *task.UserIDInquireInput) (*task
 		reLabel = append(reLabel, &reLabelListSrt)
 	}
 	reLabelSrt := &task.ReLabelListOut{
-		ReLabelListOut: reLabel,
+		ReLabelList: reLabel,
 	}
 	fmt.Printf("vxxxxx:%v\n", reLabelSrt)
 	return reLabelSrt, nil

--- a/task/internal/logic/querysubtaskstylelogic.go
+++ b/task/internal/logic/querysubtaskstylelogic.go
@@ -3,9 +3,9 @@ package logic
 import (
 	"context"
 	"github.com/zeromicro/go-zero/core/logx"
-	"taskManager-Service-main/task/internal/model"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/model"
+	"task/internal/svc"
+	"task/task"
 )
 
 type QuerySubtaskStyleLogic struct {

--- a/task/internal/logic/querytaskdetailslogic.go
+++ b/task/internal/logic/querytaskdetailslogic.go
@@ -2,10 +2,10 @@ package logic
 
 import (
 	"context"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/querytasklistlogic.go
+++ b/task/internal/logic/querytasklistlogic.go
@@ -3,10 +3,10 @@ package logic
 import (
 	"context"
 	"fmt"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/querytreasuretasklistlogic.go
+++ b/task/internal/logic/querytreasuretasklistlogic.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"taskManager-Service-main/task/internal/model"
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/model"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/queryuserlaunchtasklistlogic.go
+++ b/task/internal/logic/queryuserlaunchtasklistlogic.go
@@ -3,10 +3,10 @@ package logic
 import (
 	"context"
 	"fmt"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/logic/voluntarilytaskschedulelogic.go
+++ b/task/internal/logic/voluntarilytaskschedulelogic.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/model"
 	"time"
 
-	"taskManager-Service-main/task/internal/svc"
-	"taskManager-Service-main/task/task"
+	"task/internal/svc"
+	"task/task"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )

--- a/task/internal/svc/servicecontext.go
+++ b/task/internal/svc/servicecontext.go
@@ -2,8 +2,8 @@ package svc
 
 import (
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
-	"taskManager-Service-main/task/internal/config"
-	"taskManager-Service-main/task/internal/model"
+	"task/internal/config"
+	"task/internal/model"
 )
 
 type ServiceContext struct {

--- a/task/logs/stat.log
+++ b/task/logs/stat.log
@@ -1818,3 +1818,5 @@
 2023-06-20T13:34:50.914+08:00	[32;1m stat [0m	CPU: 0m, MEMORY: Alloc=2.6Mi, TotalAlloc=6.4Mi, Sys=18.4Mi, NumGC=84	caller=stat/usage.go:61
 2023-06-20T13:34:50.929+08:00	[32;1m stat [0m	(rpc) shedding_stat [1m], cpu: 0, total: 0, pass: 0, drop: 0	caller=load/sheddingstat.go:61
 2023-06-20T13:34:53.053+08:00	[32;1m stat [0m	(task.rpc) - qps: 0.0/s, drops: 0, avg time: 0.0ms, med: 0.0ms, 90th: 0.0ms, 99th: 0.0ms, 99.9th: 0.0ms	caller=stat/metrics.go:210
+2023-06-28T16:40:38.176+08:00	[32;1m stat [0m	CPU: 0m, MEMORY: Alloc=2.6Mi, TotalAlloc=5.3Mi, Sys=14.5Mi, NumGC=2	caller=stat/usage.go:61
+2023-06-28T16:40:38.194+08:00	[32;1m stat [0m	(rpc) shedding_stat [1m], cpu: 0, total: 0, pass: 0, drop: 0	caller=load/sheddingstat.go:61


### PR DESCRIPTION
抄送 @mangosteenLi  这次更新 将 目录机构和go-mod之间的依赖都修复了，强制合并了。其他的推送修改后记得先拉下最新分支。填充业务逻辑。将本地修改无误之后提交。